### PR TITLE
Simplifica eliminacions i cementiri

### DIFF
--- a/scripts/sample-data.ts
+++ b/scripts/sample-data.ts
@@ -133,40 +133,30 @@ async function main() {
     {
       eliminatorIndex: 0, // Martina kills Jordi
       victimIndex: 1,
-      method: 'Li he posat la pastanaga a la motxilla mentre no mirava',
-      location: 'Hall de la facultat',
       witnesses: ['Pere Sánchez', 'Anna Puig'],
       daysAgo: 5
     },
     {
       eliminatorIndex: 0, // Martina kills Bernat (after getting Jordi's target)
       victimIndex: 2,
-      method: 'Emboscada a la sortida del metro',
-      location: 'Estació L3 Palau Reial',
       witnesses: [],
       daysAgo: 3
     },
     {
       eliminatorIndex: 6, // Roger kills Laia
       victimIndex: 12,
-      method: 'Li he donat la mà amb la pastanaga amagada',
-      location: 'Entrada principal FME',
       witnesses: ['Marc Torres'],
       daysAgo: 4
     },
     {
       eliminatorIndex: 5, // Dani kills Roger
       victimIndex: 6,
-      method: 'Pastanaga ninja durant el coffee break',
-      location: 'Bar de la facultat',
       witnesses: ['Laura Martínez', 'Carles Ros'],
       daysAgo: 2
     },
     {
       eliminatorIndex: 10, // Joan kills Ernesto
       victimIndex: 11,
-      method: 'Li he deixat la pastanaga a la cadira abans que s\'assegués',
-      location: 'Aula S05',
       witnesses: [],
       daysAgo: 1
     }
@@ -183,8 +173,8 @@ async function main() {
         gameId: game.id,
         eliminatorId: eliminator.id,
         victimId: victim.id,
-        method: elim.method,
-        location: elim.location,
+        method: null,
+        location: null,
         witnesses: elim.witnesses.length > 0 ? JSON.stringify(elim.witnesses) : null,
         confirmed: true,
         timestamp: new Date(Date.now() - elim.daysAgo * 24 * 60 * 60 * 1000)

--- a/src/app/api/eliminations/route.ts
+++ b/src/app/api/eliminations/route.ts
@@ -6,8 +6,6 @@ import { z } from 'zod';
 
 const createEliminationSchema = z.object({
   targetId: z.string(),
-  method: z.string().min(1),
-  location: z.string().optional(),
   witnesses: z.array(z.string()).optional(),
   victimSignature: z.string()
 });
@@ -70,8 +68,8 @@ export async function POST(request: NextRequest) {
         gameId: participant.gameId,
         eliminatorId: participant.id,
         victimId: validatedData.targetId,
-        method: validatedData.method,
-        location: validatedData.location || null,
+        method: null,
+        location: null,
         witnesses: validatedData.witnesses ? JSON.stringify(validatedData.witnesses) : null,
         confirmed: false
       }

--- a/src/app/game/cemetery/page.tsx
+++ b/src/app/game/cemetery/page.tsx
@@ -8,14 +8,12 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
-import { ArrowLeft, Skull, Calendar, MapPin, Users } from 'lucide-react';
+import { ArrowLeft, Skull, Calendar, Users } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 interface Elimination {
   id: string;
   timestamp: string;
-  location: string | null;
-  method: string;
   witnesses: string[];
   confirmed: boolean;
   eliminator: {
@@ -148,35 +146,6 @@ export default function CemeteryPage() {
                   <div className="grid md:grid-cols-2 gap-6">
                     {/* Elimination Details */}
                     <div className="space-y-4">
-                      <div>
-                        <p className="font-semibold mb-1">Assassí:</p>
-                        <div className="flex items-center gap-2">
-                          <Avatar className="h-8 w-8">
-                            <AvatarImage src={elimination.eliminator.photo || undefined} />
-                            <AvatarFallback>
-                              {elimination.eliminator.nickname.slice(0, 2).toUpperCase()}
-                            </AvatarFallback>
-                          </Avatar>
-                          <span>{elimination.eliminator.nickname}</span>
-                          <span className="text-muted-foreground">({elimination.eliminator.group})</span>
-                        </div>
-                      </div>
-                      
-                      <div>
-                        <p className="font-semibold mb-1">Mètode:</p>
-                        <p className="text-muted-foreground">{elimination.method}</p>
-                      </div>
-
-                      {elimination.location && (
-                        <div>
-                          <p className="font-semibold mb-1 flex items-center gap-1">
-                            <MapPin className="h-4 w-4" />
-                            Localització:
-                          </p>
-                          <p className="text-muted-foreground">{elimination.location}</p>
-                        </div>
-                      )}
-
                       {elimination.witnesses.length > 0 && (
                         <div>
                           <p className="font-semibold mb-1 flex items-center gap-1">

--- a/src/components/forms/elimination-form.tsx
+++ b/src/components/forms/elimination-form.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Loader2, RefreshCw, Save, Send } from 'lucide-react';
@@ -26,8 +25,6 @@ export function EliminationForm({ targetId, targetName, targetGroup, targetPhoto
   const [hasSignature, setHasSignature] = useState(false);
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState({
-    method: '',
-    location: '',
     witnesses: ''
   });
 
@@ -117,14 +114,6 @@ export function EliminationForm({ targetId, targetName, targetGroup, targetPhoto
       return;
     }
 
-    if (!formData.method.trim()) {
-      toast({
-        title: 'Mètode requerit',
-        description: 'Has d\'especificar com has eliminat la víctima',
-        variant: 'destructive'
-      });
-      return;
-    }
 
     setLoading(true);
 
@@ -142,8 +131,6 @@ export function EliminationForm({ targetId, targetName, targetGroup, targetPhoto
         },
         body: JSON.stringify({
           targetId,
-          method: formData.method,
-          location: formData.location,
           witnesses: witnessesArray,
           victimSignature: signatureData
         })
@@ -199,34 +186,12 @@ export function EliminationForm({ targetId, targetName, targetGroup, targetPhoto
       {/* Elimination Details */}
       <Card>
         <CardHeader>
-          <CardTitle>Detalls de l'eliminació</CardTitle>
-          <CardDescription>Proporciona informació sobre com has eliminat la víctima</CardDescription>
+          <CardTitle>Testimonis (opcional)</CardTitle>
+          <CardDescription>Indica qui ha presenciat l'eliminació</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="method">Mètode d'eliminació *</Label>
-            <Textarea
-              id="method"
-              placeholder="Descriu com has eliminat la víctima..."
-              value={formData.method}
-              onChange={(e) => setFormData({ ...formData, method: e.target.value })}
-              required
-              className="min-h-[100px]"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="location">Localització (opcional)</Label>
-            <Input
-              id="location"
-              placeholder="On ha passat l'eliminació?"
-              value={formData.location}
-              onChange={(e) => setFormData({ ...formData, location: e.target.value })}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="witnesses">Testimonis (opcional)</Label>
+            <Label htmlFor="witnesses">Testimonis</Label>
             <Input
               id="witnesses"
               placeholder="Noms dels testimonis, separats per comes"
@@ -300,7 +265,7 @@ export function EliminationForm({ targetId, targetName, targetGroup, targetPhoto
         type="submit" 
         size="lg" 
         className="w-full"
-        disabled={loading || !hasSignature || !formData.method}
+        disabled={loading || !hasSignature}
       >
         {loading ? (
           <>


### PR DESCRIPTION
## Resum
- elimina camps de mètode i localització al report d'eliminació
- simplifica formulari de reportar eliminació
- oculta informació de l'assassí al cementiri i mostra només testimonis i signatura
- adapta dades de mostra i API

## Testing
- `npm run lint` *(falla: `next` no està instal·lat)*